### PR TITLE
Fix early leave calculation in checkout handler

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -131,7 +131,7 @@ export function registerRoutes(app: Express) {
       }
 
       const checkOutTime = new Date();
-      const isEarlyLeave = checkOutTime.getHours() < 21 || (checkOutTime.getHours() === 21 && checkOutTime.getMinutes() < 0);
+      const isEarlyLeave = checkOutTime.getHours() < 21;
       
       // Calculate hours worked
       const hoursWorked = (checkOutTime.getTime() - existingRecord.checkInTime.getTime()) / (1000 * 60 * 60);


### PR DESCRIPTION
## Summary
- simplify early leave detection to rely only on hour comparison

## Testing
- `npm run check` *(fails: Cannot find module 'multer' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aad9a3168c83338657fc77621ae797