### PR TITLE
Clarify DATABASE_URL error message in Drizzle config

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "drizzle-kit";
 
 if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL, ensure the database is provisioned");
+  throw new Error("DATABASE_URL must be set; ensure the database is provisioned");
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- clarify the thrown error when DATABASE_URL env var is missing in drizzle config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aad9c82674833386adcb31131d1e95