### PR TITLE
Implement audio deletion with waveform timeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.env
+server/uploads/

--- a/clear-attendance.js
+++ b/clear-attendance.js
@@ -1,0 +1,77 @@
+
+import 'dotenv/config';
+import { db } from './server/db.js';
+import { attendanceRecords, audioRecordings, users } from './shared/schema.js';
+import { sql, eq, and } from 'drizzle-orm';
+import readline from 'readline';
+
+const today = '2025-08-25';
+
+async function clearAttendance() {
+  try {
+    const usersWithMultipleEntries = await db
+      .select({
+        userId: attendanceRecords.userId,
+        username: users.username,
+        count: sql`count(${attendanceRecords.id})`,
+      })
+      .from(attendanceRecords)
+      .leftJoin(users, eq(users.id, attendanceRecords.userId))
+      .where(eq(attendanceRecords.date, today))
+      .groupBy(attendanceRecords.userId, users.username)
+      .having(sql`count(${attendanceRecords.id}) > 1`);
+
+    if (usersWithMultipleEntries.length === 0) {
+      console.log("No users with multiple attendance entries for today.");
+      process.exit(0);
+    }
+
+    console.log("Users with multiple attendance entries for today:");
+    usersWithMultipleEntries.forEach((user, index) => {
+      console.log(`${index + 1}. ${user.username} (User ID: ${user.userId}) - ${user.count} entries`);
+    });
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+
+    rl.question("Enter the number of the user whose attendance you want to clear (or type 'all' to clear for all listed users, or 'exit' to cancel): ", async (answer) => {
+      if (answer.toLowerCase() === 'exit') {
+        console.log("Operation cancelled.");
+        rl.close();
+        process.exit(0);
+      }
+      
+      let usersToClear = [];
+      if (answer.toLowerCase() === 'all') {
+        usersToClear = usersWithMultipleEntries.map(u => u.userId);
+      } else {
+        const userIndex = parseInt(answer) - 1;
+        if (userIndex >= 0 && userIndex < usersWithMultipleEntries.length) {
+          usersToClear.push(usersWithMultipleEntries[userIndex].userId);
+        } else {
+          console.log("Invalid selection.");
+          rl.close();
+          process.exit(1);
+        }
+      }
+
+      for (const userId of usersToClear) {
+        await db.delete(audioRecordings).where(and(eq(audioRecordings.userId, userId), eq(audioRecordings.recordingDate, today)));
+        await db.delete(attendanceRecords).where(and(eq(attendanceRecords.userId, userId), eq(attendanceRecords.date, today)));
+        const user = usersWithMultipleEntries.find(u => u.userId === userId);
+        console.log(`Cleared attendance for ${user.username} (User ID: ${userId})`);
+      }
+
+      rl.close();
+      process.exit(0);
+    });
+
+  } catch (error) {
+    console.error("Error:", error.message);
+    process.exit(1);
+  }
+}
+
+clearAttendance();

--- a/client/src/components/audio-timeline.tsx
+++ b/client/src/components/audio-timeline.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react";
+
+// Renders a simple waveform visualization for an audio file
+
+interface AudioTimelineProps {
+  fileUrl: string;
+}
+
+export function AudioTimeline({ fileUrl }: AudioTimelineProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [segments, setSegments] = useState<number[]>([]);
+
+  useEffect(() => {
+    const analyze = async () => {
+      try {
+        const res = await fetch(fileUrl);
+        const arrayBuffer = await res.arrayBuffer();
+        const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+        const audioCtx = new AudioCtx();
+        const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+        const rawData = audioBuffer.getChannelData(0);
+        const sampleSize = Math.floor(rawData.length / 100);
+        const amplitude: number[] = [];
+        for (let i = 0; i < 100; i++) {
+          let sum = 0;
+          for (let j = 0; j < sampleSize; j++) {
+            sum += Math.abs(rawData[i * sampleSize + j]);
+          }
+          amplitude.push(sum / sampleSize);
+        }
+        setSegments(amplitude);
+      } catch (err) {
+        console.error("Audio analysis failed", err);
+      }
+    };
+    analyze();
+  }, [fileUrl]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || segments.length === 0) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const width = canvas.width;
+    const height = canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    segments.forEach((value, index) => {
+      const x = (index / segments.length) * width;
+      const barWidth = width / segments.length;
+      const barHeight = value * height;
+      ctx.fillStyle = value > 0.05 ? "#2563eb" : "#cbd5e1";
+      ctx.fillRect(x, height - barHeight, barWidth, barHeight);
+    });
+  }, [segments]);
+
+  return <canvas ref={canvasRef} width={400} height={60} className="w-full h-16" />;
+}
+
+export default AudioTimeline;

--- a/client/src/components/audio-timeline.tsx
+++ b/client/src/components/audio-timeline.tsx
@@ -91,7 +91,7 @@ export function AudioTimeline({ fileUrl, startTime, duration, audioRef }: AudioT
       const height = canvas.clientHeight;
       if (canvas.width !== width) canvas.width = width;
       if (canvas.height !== height) canvas.height = height;
-      const timelineHeight = 12;
+      const timelineHeight = 16;
       const waveformHeight = height - timelineHeight;
       ctx.clearRect(0, 0, width, height);
 
@@ -100,7 +100,7 @@ export function AudioTimeline({ fileUrl, startTime, duration, audioRef }: AudioT
         const x = (index / segments.length) * width;
         const barWidth = width / segments.length;
         const barHeight = value * waveformHeight;
-        ctx.fillStyle = value > 0.02 ? "#facc15" : "#e5e7eb"; // yellow for voice
+        ctx.fillStyle = value > 0.01 ? "#facc15" : "#e5e7eb"; // yellow for voice
         ctx.fillRect(x, waveformHeight - barHeight, barWidth, barHeight);
       });
 
@@ -159,7 +159,9 @@ export function AudioTimeline({ fileUrl, startTime, duration, audioRef }: AudioT
     const rect = canvasRef.current!.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const width = rect.width;
-    audioRef.current.currentTime = (x / width) * totalDuration;
+    const audio = audioRef.current;
+    audio.currentTime = (x / width) * totalDuration;
+    audio.play().catch(() => {});
   };
 
   return (
@@ -168,8 +170,8 @@ export function AudioTimeline({ fileUrl, startTime, duration, audioRef }: AudioT
       <canvas
         ref={canvasRef}
         width={400}
-        height={50}
-        className="h-12 flex-1 cursor-pointer"
+        height={80}
+        className="h-20 flex-1 cursor-pointer"
         onClick={handleClick}
       />
       <span className="text-xs text-gray-600 w-14 text-right">{endLabel}</span>

--- a/client/src/components/audio-timeline.tsx
+++ b/client/src/components/audio-timeline.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-// Renders a simple waveform visualization for an audio file
+// Renders a waveform timeline with optional start/end time labels
 
 interface AudioTimelineProps {
   fileUrl: string;
@@ -12,6 +12,7 @@ export function AudioTimeline({ fileUrl, startTime, duration }: AudioTimelinePro
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [segments, setSegments] = useState<number[]>([]);
 
+  // Analyze the audio file once to generate simple amplitude segments
   useEffect(() => {
     const analyze = async () => {
       try {
@@ -38,6 +39,7 @@ export function AudioTimeline({ fileUrl, startTime, duration }: AudioTimelinePro
     analyze();
   }, [fileUrl]);
 
+  // Draw the waveform bars
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas || segments.length === 0) return;
@@ -49,31 +51,31 @@ export function AudioTimeline({ fileUrl, startTime, duration }: AudioTimelinePro
     segments.forEach((value, index) => {
       const x = (index / segments.length) * width;
       const barWidth = width / segments.length;
-      const barHeight = value * (height - 20); // leave space for labels
-      ctx.fillStyle = value > 0.05 ? "#facc15" : "#e5e7eb"; // yellow for voice
-      ctx.fillRect(x, (height - 20) - barHeight, barWidth, barHeight);
+      const barHeight = value * height;
+      ctx.fillStyle = value > 0.05 ? "#facc15" : "#e5e7eb"; // yellow when voice is detected
+      ctx.fillRect(x, height - barHeight, barWidth, barHeight);
     });
+  }, [segments]);
 
-    const startLabel = startTime
-      ? new Date(startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-      : '0:00';
-    const endLabel = (() => {
-      if (startTime && typeof duration === 'number') {
-        const end = new Date(new Date(startTime).getTime() + duration * 1000);
-        return end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-      }
-      return duration ? `${duration}s` : '';
-    })();
+  const startLabel = startTime
+    ? new Date(startTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+    : "0:00";
 
-    ctx.fillStyle = '#4b5563';
-    ctx.font = '12px sans-serif';
-    ctx.textBaseline = 'bottom';
-    ctx.fillText(startLabel, 0, height);
-    const endWidth = ctx.measureText(endLabel).width;
-    ctx.fillText(endLabel, width - endWidth, height);
-  }, [segments, startTime, duration]);
+  const endLabel = (() => {
+    if (startTime && typeof duration === "number") {
+      const end = new Date(new Date(startTime).getTime() + duration * 1000);
+      return end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    }
+    return duration ? `${duration}s` : "";
+  })();
 
-  return <canvas ref={canvasRef} width={600} height={80} className="w-full h-20" />;
+  return (
+    <div className="flex items-center gap-2 mt-2">
+      <span className="text-xs text-gray-600 w-14 text-left">{startLabel}</span>
+      <canvas ref={canvasRef} width={400} height={40} className="h-10 flex-1" />
+      <span className="text-xs text-gray-600 w-14 text-right">{endLabel}</span>
+    </div>
+  );
 }
 
 export default AudioTimeline;

--- a/client/src/components/audio-timeline.tsx
+++ b/client/src/components/audio-timeline.tsx
@@ -86,8 +86,11 @@ export function AudioTimeline({ fileUrl, startTime, duration, audioRef }: AudioT
     if (!ctx) return;
 
     const draw = () => {
-      const width = canvas.width;
-      const height = canvas.height;
+      // Ensure canvas matches its display size
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+      if (canvas.width !== width) canvas.width = width;
+      if (canvas.height !== height) canvas.height = height;
       const timelineHeight = 12;
       const waveformHeight = height - timelineHeight;
       ctx.clearRect(0, 0, width, height);
@@ -151,10 +154,24 @@ export function AudioTimeline({ fileUrl, startTime, duration, audioRef }: AudioT
     return totalDuration > 0 ? formatTime(totalDuration) : "";
   })();
 
+  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!audioRef?.current || totalDuration <= 0) return;
+    const rect = canvasRef.current!.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const width = rect.width;
+    audioRef.current.currentTime = (x / width) * totalDuration;
+  };
+
   return (
     <div className="flex items-center gap-2 mt-2">
       <span className="text-xs text-gray-600 w-14 text-left">{startLabel}</span>
-      <canvas ref={canvasRef} width={400} height={50} className="h-12 flex-1" />
+      <canvas
+        ref={canvasRef}
+        width={400}
+        height={50}
+        className="h-12 flex-1 cursor-pointer"
+        onClick={handleClick}
+      />
       <span className="text-xs text-gray-600 w-14 text-right">{endLabel}</span>
     </div>
   );

--- a/client/src/components/audio-timeline.tsx
+++ b/client/src/components/audio-timeline.tsx
@@ -4,9 +4,11 @@ import { useEffect, useRef, useState } from "react";
 
 interface AudioTimelineProps {
   fileUrl: string;
+  startTime?: string | Date;
+  duration?: number; // seconds
 }
 
-export function AudioTimeline({ fileUrl }: AudioTimelineProps) {
+export function AudioTimeline({ fileUrl, startTime, duration }: AudioTimelineProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [segments, setSegments] = useState<number[]>([]);
 
@@ -47,13 +49,31 @@ export function AudioTimeline({ fileUrl }: AudioTimelineProps) {
     segments.forEach((value, index) => {
       const x = (index / segments.length) * width;
       const barWidth = width / segments.length;
-      const barHeight = value * height;
-      ctx.fillStyle = value > 0.05 ? "#2563eb" : "#cbd5e1";
-      ctx.fillRect(x, height - barHeight, barWidth, barHeight);
+      const barHeight = value * (height - 20); // leave space for labels
+      ctx.fillStyle = value > 0.05 ? "#facc15" : "#e5e7eb"; // yellow for voice
+      ctx.fillRect(x, (height - 20) - barHeight, barWidth, barHeight);
     });
-  }, [segments]);
 
-  return <canvas ref={canvasRef} width={400} height={60} className="w-full h-16" />;
+    const startLabel = startTime
+      ? new Date(startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+      : '0:00';
+    const endLabel = (() => {
+      if (startTime && typeof duration === 'number') {
+        const end = new Date(new Date(startTime).getTime() + duration * 1000);
+        return end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      }
+      return duration ? `${duration}s` : '';
+    })();
+
+    ctx.fillStyle = '#4b5563';
+    ctx.font = '12px sans-serif';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText(startLabel, 0, height);
+    const endWidth = ctx.measureText(endLabel).width;
+    ctx.fillText(endLabel, width - endWidth, height);
+  }, [segments, startTime, duration]);
+
+  return <canvas ref={canvasRef} width={600} height={80} className="w-full h-20" />;
 }
 
 export default AudioTimeline;

--- a/client/src/lib/audio-recorder.ts
+++ b/client/src/lib/audio-recorder.ts
@@ -75,15 +75,15 @@ export class AudioRecorder {
       this.mediaRecorder.onstop = async () => {
         const blob = new Blob(this.chunks, { type: 'audio/webm;codecs=opus' });
         const duration = this.startTime ? Math.floor((Date.now() - this.startTime.getTime()) / 1000) : 0;
-        
+
         console.log(`🔴 Recording stopped - Duration: ${duration}s, Size: ${blob.size} bytes`);
-        
+
         if (blob.size > 0) {
-          await this.uploadAudio(blob);
+          await this.uploadAudio(blob, duration);
         } else {
           console.warn('⚠️ Recording blob is empty, skipping upload');
         }
-        
+
         this.cleanup();
         resolve(blob);
       };
@@ -93,14 +93,15 @@ export class AudioRecorder {
     });
   }
 
-  private async uploadAudio(blob: Blob): Promise<void> {
+  private async uploadAudio(blob: Blob, duration: number): Promise<void> {
     try {
       console.log(`📤 Uploading audio blob: ${blob.size} bytes`);
-      
+
       const formData = new FormData();
       const timestamp = Date.now();
       const filename = `recording-${timestamp}.webm`;
       formData.append('audio', blob, filename);
+      formData.append('duration', duration.toString());
 
       const response = await fetch('/api/audio/upload', {
         method: 'POST',

--- a/client/src/pages/admin-audio.tsx
+++ b/client/src/pages/admin-audio.tsx
@@ -456,7 +456,7 @@ export default function AdminAudio() {
                                     <X className="h-4 w-4" />
                                   </Button>
                                 </div>
-                                <audio ref={audioRef} controls className="w-full" />
+                                <audio ref={audioRef} controls preload="metadata" className="w-full" />
                                 {recording.fileUrl && (
                                   <AudioTimeline
                                     fileUrl={recording.fileUrl}

--- a/client/src/pages/admin-audio.tsx
+++ b/client/src/pages/admin-audio.tsx
@@ -168,21 +168,9 @@ export default function AdminAudio() {
 
   useEffect(() => {
     if (selectedRecording && audioRef.current) {
-      audioRef.current.currentTime = 0;
+      audioRef.current.pause();
       audioRef.current.src = selectedRecording.fileUrl!;
-      audioRef.current.play().then(() => {
-        toast({
-          title: "Audio playback",
-          description: `Playing ${selectedRecording.fileName}`,
-        });
-      }).catch((error) => {
-        console.error('Audio play error:', error);
-        toast({
-          title: "Playback failed",
-          description: error.message,
-          variant: "destructive",
-        });
-      });
+      audioRef.current.currentTime = 0;
     }
   }, [selectedRecording]);
 

--- a/client/src/pages/admin-audio.tsx
+++ b/client/src/pages/admin-audio.tsx
@@ -436,7 +436,7 @@ export default function AdminAudio() {
                                   <AudioTimeline
                                     fileUrl={recording.fileUrl}
                                     startTime={recording.createdAt ?? undefined}
-                                    duration={recording.duration || 0}
+                                    duration={recording.duration ?? undefined}
                                     audioRef={audioRef}
                                   />
                                 )}

--- a/client/src/pages/admin-audio.tsx
+++ b/client/src/pages/admin-audio.tsx
@@ -456,7 +456,13 @@ export default function AdminAudio() {
                                     <X className="h-4 w-4" />
                                   </Button>
                                 </div>
-                                <audio ref={audioRef} controls preload="metadata" className="w-full" />
+                                <audio
+                                  key={recording.id}
+                                  ref={audioRef}
+                                  controls
+                                  preload="metadata"
+                                  className="w-full"
+                                />
                                 {recording.fileUrl && (
                                   <AudioTimeline
                                     fileUrl={recording.fileUrl}

--- a/client/src/pages/admin-audio.tsx
+++ b/client/src/pages/admin-audio.tsx
@@ -437,6 +437,7 @@ export default function AdminAudio() {
                                     fileUrl={recording.fileUrl}
                                     startTime={recording.createdAt ?? undefined}
                                     duration={recording.duration || 0}
+                                    audioRef={audioRef}
                                   />
                                 )}
                               </div>

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -40,6 +40,10 @@ export default function AdminDashboard() {
     refetchInterval: 30000,
   });
 
+  const { data: employees } = useQuery<User[]>({
+    queryKey: ["/api/admin/employees"],
+  });
+
   const audioForm = useForm<z.infer<typeof audioPasswordSchema>>({
     resolver: zodResolver(audioPasswordSchema),
     defaultValues: {
@@ -65,13 +69,9 @@ export default function AdminDashboard() {
   };
 
   const getStats = () => {
-    if (!todayAttendance) return { total: 0, present: 0, late: 0, absent: 0 };
-
-    const present = todayAttendance.length;
-    const late = todayAttendance.filter(record => record.isLate).length;
-    
-    // Mock total employees - in real app this would come from a separate query
-    const total = 24;
+    const total = employees?.length ?? 0;
+    const present = todayAttendance?.length ?? 0;
+    const late = todayAttendance?.filter(record => record.isLate).length ?? 0;
     const absent = total - present;
 
     return { total, present, late, absent };

--- a/client/src/pages/admin-work-hours.tsx
+++ b/client/src/pages/admin-work-hours.tsx
@@ -24,8 +24,10 @@ import {
 export default function AdminWorkHours() {
   const { user } = useAuth();
   
-  // Get current month as default (YYYY-MM format)
-  const currentMonth = new Date().toISOString().slice(0, 7);
+  // Default to previous month (YYYY-MM format)
+  const now = new Date();
+  const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const currentMonth = lastMonth.toISOString().slice(0, 7);
   const [selectedMonth, setSelectedMonth] = useState(currentMonth);
 
   const { data: workHoursData, isLoading, error } = useQuery<MonthlyWorkHoursResponse>({

--- a/client/src/pages/employee-dashboard.tsx
+++ b/client/src/pages/employee-dashboard.tsx
@@ -182,9 +182,15 @@ export default function EmployeeDashboard() {
       });
     }
   };
+  const handleCheckOut = () => {
+    if (confirm("Are you sure you want to check out?")) {
+      checkOutMutation.mutate();
+    }
+  };
 
+  const hasAttendance = !!todayAttendance;
   const isCheckedIn = todayAttendance && !todayAttendance.checkOutTime;
-  const canCheckIn = !isCheckedIn; // Allow check-in from anywhere for testing
+  const canCheckIn = !hasAttendance;
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -265,7 +271,7 @@ export default function EmployeeDashboard() {
                   : "bg-gray-400 cursor-not-allowed"
               }`}
               disabled={(!canCheckIn && !isCheckedIn) || checkInMutation.isPending || checkOutMutation.isPending}
-              onClick={isCheckedIn ? () => checkOutMutation.mutate() : handleCheckIn}
+              onClick={isCheckedIn ? handleCheckOut : handleCheckIn}
               data-testid={isCheckedIn ? "button-checkout" : "button-checkin"}
             >
               {(checkInMutation.isPending || checkOutMutation.isPending) && (
@@ -276,7 +282,11 @@ export default function EmployeeDashboard() {
               )}
             </Button>
             <p className="text-xs text-gray-500">
-              {isCheckedIn ? "Tap to stop work" : "Tap to start work"}
+              {isCheckedIn
+                ? "Tap to stop work"
+                : hasAttendance
+                ? "Today's attendance recorded"
+                : "Tap to start work"}
             </p>
           </CardContent>
         </Card>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -406,6 +406,36 @@ export function registerRoutes(app: Express) {
     }
   });
 
+  app.delete("/api/admin/audio/:id", async (req, res) => {
+    try {
+      const recording = await storage.getAudioRecordingById(req.params.id);
+      if (!recording) {
+        return res.status(404).json({ message: "Recording not found" });
+      }
+
+      if (recording.fileName) {
+        const filePath = path.join(
+          __dirname,
+          'uploads',
+          'audio',
+          recording.userId,
+          recording.fileName
+        );
+        try {
+          await fs.promises.unlink(filePath);
+        } catch (err) {
+          console.warn('File delete error:', err);
+        }
+      }
+
+      await storage.deleteAudioRecording(req.params.id);
+      res.json({ message: "Recording deleted" });
+    } catch (error) {
+      console.error('Delete recording error:', error);
+      res.status(500).json({ message: "Failed to delete recording" });
+    }
+  });
+
   return httpServer;
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -262,6 +262,25 @@ export function registerRoutes(app: Express) {
     }
   });
 
+  app.put("/api/admin/employees/:id", async (req, res) => {
+    if (!req.isAuthenticated() || req.user?.role !== "admin") {
+      return res.status(401).json({ message: "Admin access required" });
+    }
+
+    try {
+      const { username, employeeId, department, password } = req.body;
+      const updateData: any = { username, employeeId, department };
+      if (password) {
+        updateData.password = await hashPassword(password);
+      }
+      const user = await storage.updateUser(req.params.id, updateData);
+      res.json(user);
+    } catch (error) {
+      console.error('Update employee error:', error);
+      res.status(500).json({ message: "Failed to update employee" });
+    }
+  });
+
   app.delete("/api/admin/employees/:id", async (req, res) => {
     if (!req.isAuthenticated() || req.user?.role !== "admin") {
       return res.status(401).json({ message: "Admin access required" });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -22,9 +22,11 @@ export interface IStorage {
   // Audio methods
   createAudioRecording(recording: InsertAudioRecording): Promise<AudioRecording>;
   updateAudioRecording(id: string, recording: Partial<AudioRecording>): Promise<AudioRecording | undefined>;
+  getAudioRecordingById(id: string): Promise<AudioRecording | undefined>;
   getAudioRecordingsByUserId(userId: string): Promise<AudioRecording[]>;
   getAllAudioRecordings(): Promise<(AudioRecording & { user: User })[]>;
   getActiveAudioRecordings(): Promise<(AudioRecording & { user: User })[]>;
+  deleteAudioRecording(id: string): Promise<void>;
   deleteOldAudioRecordings(daysOld: number): Promise<void>;
   
   // Admin methods
@@ -140,6 +142,14 @@ export class DatabaseStorage implements IStorage {
     return updatedRecording || undefined;
   }
 
+  async getAudioRecordingById(id: string): Promise<AudioRecording | undefined> {
+    const [recording] = await db
+      .select()
+      .from(audioRecordings)
+      .where(eq(audioRecordings.id, id));
+    return recording || undefined;
+  }
+
   async getAudioRecordingsByUserId(userId: string): Promise<AudioRecording[]> {
     return await db
       .select()
@@ -186,6 +196,10 @@ export class DatabaseStorage implements IStorage {
       .from(audioRecordings)
       .innerJoin(users, eq(audioRecordings.userId, users.id))
       .where(eq(audioRecordings.isActive, true));
+  }
+
+  async deleteAudioRecording(id: string): Promise<void> {
+    await db.delete(audioRecordings).where(eq(audioRecordings.id, id));
   }
 
   async deleteOldAudioRecordings(daysOld: number): Promise<void> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -23,6 +23,7 @@ export interface IStorage {
   createAudioRecording(recording: InsertAudioRecording): Promise<AudioRecording>;
   updateAudioRecording(id: string, recording: Partial<AudioRecording>): Promise<AudioRecording | undefined>;
   getAudioRecordingById(id: string): Promise<AudioRecording | undefined>;
+  getActiveAudioRecordingByAttendance(attendanceId: string): Promise<AudioRecording | undefined>;
   getAudioRecordingsByUserId(userId: string): Promise<AudioRecording[]>;
   getAllAudioRecordings(): Promise<(AudioRecording & { user: User })[]>;
   getActiveAudioRecordings(): Promise<(AudioRecording & { user: User })[]>;
@@ -147,6 +148,14 @@ export class DatabaseStorage implements IStorage {
       .select()
       .from(audioRecordings)
       .where(eq(audioRecordings.id, id));
+    return recording || undefined;
+  }
+
+  async getActiveAudioRecordingByAttendance(attendanceId: string): Promise<AudioRecording | undefined> {
+    const [recording] = await db
+      .select()
+      .from(audioRecordings)
+      .where(and(eq(audioRecordings.attendanceId, attendanceId), eq(audioRecordings.isActive, true)));
     return recording || undefined;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -13,6 +13,7 @@ export const users = pgTable("users", {
   department: text("department"),
   joinDate: timestamp("join_date").defaultNow(),
   isActive: boolean("is_active").default(true),
+  isLoggedIn: boolean("is_logged_in").default(false),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -71,6 +72,7 @@ export const audioRecordingsRelations = relations(audioRecordings, ({ one }) => 
 export const insertUserSchema = createInsertSchema(users).omit({
   id: true,
   createdAt: true,
+  isLoggedIn: true,
 });
 
 export const insertAttendanceSchema = createInsertSchema(attendanceRecords).omit({


### PR DESCRIPTION
## Summary
- allow admins to delete audio recordings through a new server endpoint and storage helpers
- display selected recording playback with waveform timeline and fix playback handling in admin audio panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Argument of type 'Date' is not assignable to parameter of type 'string')*

------
https://chatgpt.com/codex/tasks/task_e_68abf6eed94c8333838a37cc1cdb5126